### PR TITLE
Devcontainer build fails on Debian trixie due to Docker-in-Docker moby default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,9 @@
             "nodeGypDependencies": false
         },
         "ghcr.io/devcontainers/features/azure-cli:1.2.5": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
+        },
         "ghcr.io/azure/azure-dev/azd:latest": {}
     },
     "customizations": {


### PR DESCRIPTION
## Purpose

Devcontainer builds currently fail on Debian trixie because the Docker-in-Docker feature defaults to `moby=true`, which doesn't seem to be supported anymore. Opening the repo in VS Code Dev Containers and rebuilding stops during the Docker-in-Docker install step with an error about moby packages being unavailable. Switching to a different base image might also be a solution.

> [!WARNING]
> I couldn’t run the test suite in this PR because the repo currently pins `azure-search-documents==11.7.0b2`, which removed the `azure.search.documents.agent` API that the tests still import, causing pytest to fail during test discovery.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.


