### PR TITLE
bump markdown-checker to 1.3.1

### DIFF
--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -2,7 +2,7 @@ name: Validate Markdown
 
 on:
   # Trigger the workflow on pull request
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Check broken Paths
         id: check-broken-paths
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_broken_paths
           directory: ./
@@ -37,12 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run Check URLs Country Locale
         id: check-urls-locale
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_urls_locale
           directory: ./
@@ -54,12 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run Check Broken URLs
         id: check-broken-urls
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_broken_urls
           directory: ./


### PR DESCRIPTION
Hey 👋🏼,
Thank you for using the tool.
I recently used zizmor to audit the package and fixed all the issues it flagged.

This update includes:
- Sticky comments, only one comment will be posted per command used instead of spamming the pull request with every push.
- zizmor security fixes.
- Only posting comments to pull requests for push we update summary of job and mark it as failed/succeed.
- I pinned `markdown-checker` the python package behind this tool since I saw unpinned dependencies causing lots of issues everywhere.
- Due to `pull_request: write` GitHub restrictions it's no longer required since commenting won't work unless the pull request is not from a fork. only updating the summary and GitHub annotations.

For more info check: https://markdown-checker.readthedocs.io/en/latest/howto/github-actions/